### PR TITLE
add link to issues, incorporate issues into agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
+[![GitHub issues](https://img.shields.io/github/issues/badges/shields.svg)](https:github.com/dcppc/2018-july-workshop)
+
 # 2018-july-workshop
 
 Welcome! This repository contains the website for the July 2018 DCPPC Workshop, will be held on July 25-26 at The Renaissance Computing Institute (RENCI), an institute of the University of North Carolina at Chapel Hill, which is located at [100 Europa Drive, Suite 540, Chapel Hill, NC 27517](https://www.google.com/maps/place/100+Europa+Dr,+Chapel+Hill,+NC+27517/@35.9392635,-79.020576,17z/data=!3m1!4b1!4m5!3m4!1s0x89ace7f888b92489:0x726a47e95db81d35!8m2!3d35.9392635!4d-79.0183873). RENCI is located about 4 miles from the University of North Carolina at Chapel Hill campus and about 18 miles from RDU airport.
 
 The 2018 July Workshop website is available here: [http://nih-data-commons.us/2018-july-workshop](http://nih-data-commons.us/2018-july-workshop)
 
-This website is automatically generated from Markdown files in the `docs/` folder of this repository.
+The [main agenda](http://nih-data-commons.us/2018-july-workshop/agenda) provides and overview of the events and times. 
+
+### Contributing
 To add or modify content on the workshop website, edit the corresponding file in the `docs/` folder.
 
-The site title, Github URL, and other information is set in `docs/_config.yml`, a YAML configuration file.
+View or contribute to the the living agenda by reading the [open Issues](https://github.com/dcppc/2018-july-workshop/issues). 
+
+All contributors should agree to the code of conduct.
 

--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -69,6 +69,9 @@ For up-to date list, [visit the issue page](https://github.com/dcppc/2018-july-w
 
 | Github Issue Links |
 | ------------------ |
+| TBD: [FAIR assessment](https://github.com/dcppc/2018-july-workshop/issues/19) |
+| TBD: [Crosscut metadata models](https://github.com/dcppc/2018-july-workshop/issues/18) |
+| TBD: [VDS and whitelists](https://github.com/dcppc/2018-july-workshop/issues/17) |
 | TBD: [The RFC process](https://github.com/dcppc/2018-july-workshop/issues/16) |
 | TBD: [Cross-stack compute](https://github.com/dcppc/2018-july-workshop/issues/14) |
 | TBD: [On boarding](https://github.com/dcppc/2018-july-workshop/issues/12) |

--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -15,12 +15,12 @@ tagline: Agenda
 
 09:40 - Lightning talks: The awesome things you have accomplished in the past.
 
-_To view the speaker order and to indicate who will represent your team, please visit [this issue](https://github.com/dcppc/2018-july-workshop/issues/). Each speaker will have 5 minutes to present and 3 minutes for Q&A._
+_To view the speaker order and to indicate who will represent your team, please visit [this Lightning Talks Day 1issue](https://github.com/dcppc/2018-july-workshop/issues/4). Each speaker will have 5 minutes to present and 3 minutes for Q&A._
    
 10:30 - Coffee break (~20 minutes)
  
-12:00 - Lunch (1 hour)         
-
+12:00 - Lunch (1 hour) 
+    
 13:00 - Breakout sessions
 
 _For up-to-date information on breakout sessions, please visit the [July Workshop issues page](https://github.com/dcppc/2018-july-workshop/issues)_
@@ -41,9 +41,9 @@ _For up-to-date information on breakout sessions, please visit the [July Worksho
 
 09:10 - Question and Answer with Team Hydrogen
  
-09:30 - Lightning talks: The awesome things you  hope to accomplish in the future.
+09:30 - Lightning talks: The awesome things you  hope to accomplish in the future. Each speaker will have 5 minutes to present and 3 minutes for Q&A.
 
-_To view the speaker order and to indicate who will represent your team, please visit [this issue](https://github.com/dcppc/2018-july-workshop/issues/). Each speaker will have 5 minutes to present and 3 minutes for Q&A._
+_To view the speaker order and to indicate who will represent your team, please visit [this issue](https://github.com/dcppc/2018-july-workshop/issues/)._
 
 10:30 - Coffee break (~20 minutes)
  
@@ -62,3 +62,16 @@ _For up-to-date information on breakout sessions, please visit the [July Worksho
 16:20 - Closing remarks
 
 16:30 - End
+
+### Proposed Breakout sessions
+
+For up-to date list, [visit the issue page](https://github.com/dcppc/2018-july-workshop/issues?q=is%3Aissue+is%3Aopen+label%3A%22proposed+session%22) filtered for proposed session.
+
+| Github Issue Links |
+| ------------------ |
+| TBD: [Cross-stack compute](https://github.com/dcppc/2018-july-workshop/issues/14) |
+| TBD: [On boarding](https://github.com/dcppc/2018-july-workshop/issues/12) |
+| Day 2: Data access and security](https://github.com/dcppc/2018-july-workshop/issues/13) |
+| Day 2: [KC6 standardization](https://github.com/dcppc/2018-july-workshop/issues/7) |
+| Day 1: [Consent ethics and security](https://github.com/dcppc/2018-july-workshop/issues/8) |
+| Day 1: [KC2 and full stacks meetup](https://github.com/dcppc/2018-july-workshop/issues/6) |

--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -69,6 +69,7 @@ For up-to date list, [visit the issue page](https://github.com/dcppc/2018-july-w
 
 | Github Issue Links |
 | ------------------ |
+| TBD: [The RFC process](https://github.com/dcppc/2018-july-workshop/issues/16) |
 | TBD: [Cross-stack compute](https://github.com/dcppc/2018-july-workshop/issues/14) |
 | TBD: [On boarding](https://github.com/dcppc/2018-july-workshop/issues/12) |
 | Day 2: [Data access and security](https://github.com/dcppc/2018-july-workshop/issues/13) |

--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -71,7 +71,7 @@ For up-to date list, [visit the issue page](https://github.com/dcppc/2018-july-w
 | ------------------ |
 | TBD: [Cross-stack compute](https://github.com/dcppc/2018-july-workshop/issues/14) |
 | TBD: [On boarding](https://github.com/dcppc/2018-july-workshop/issues/12) |
-| Day 2: Data access and security](https://github.com/dcppc/2018-july-workshop/issues/13) |
+| Day 2: [Data access and security](https://github.com/dcppc/2018-july-workshop/issues/13) |
 | Day 2: [KC6 standardization](https://github.com/dcppc/2018-july-workshop/issues/7) |
 | Day 1: [Consent ethics and security](https://github.com/dcppc/2018-july-workshop/issues/8) |
 | Day 1: [KC2 and full stacks meetup](https://github.com/dcppc/2018-july-workshop/issues/6) |

--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -75,7 +75,6 @@ For up-to date list, [visit the issue page](https://github.com/dcppc/2018-july-w
 | TBD: [The RFC process](https://github.com/dcppc/2018-july-workshop/issues/16) |
 | TBD: [Cross-stack compute](https://github.com/dcppc/2018-july-workshop/issues/14) |
 | TBD: [On boarding](https://github.com/dcppc/2018-july-workshop/issues/12) |
-| Day 2: [Data access and security](https://github.com/dcppc/2018-july-workshop/issues/13) |
 | Day 2: [KC6 standardization](https://github.com/dcppc/2018-july-workshop/issues/7) |
 | Day 1: [Consent ethics and security](https://github.com/dcppc/2018-july-workshop/issues/8) |
 | Day 1: [KC2 and full stacks meetup](https://github.com/dcppc/2018-july-workshop/issues/6) |


### PR DESCRIPTION
This PR includes a 1) manually-crated table of issues (labelled with proposed session) into the agenda and 2) add more pointers to the agenda and the issues in the README file. I'm hoping for better information flow.